### PR TITLE
fix: 去掉prefix，改用path设定cdn路径，并且修正webserver路径

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -145,7 +145,7 @@ class Builder {
         const cdn = options.cdn || '11.url.cn';
         const product = options.product || 'now';
         // Html 路径前缀, 打包时的目录
-        const htmlPrefix = moduleName ? `../../webserver/${bizName}` : '../../webserver';
+        const htmlPrefix = moduleName ? `../../webserver/${bizName}` : '../webserver';
         // Css, Js, Img等静态资源路径前缀, 打包时的目录
         const assetsPrefix = moduleName ? `cdn/${bizName}` : 'cdn';
         const cdnUrl = moduleName ? `//${cdn}/${product}/${moduleName}/${bizName}` : `//${cdn}/${product}/${bizName}`;
@@ -249,7 +249,6 @@ class Builder {
         if (useHash) {
             hash = '_[chunkhash:8]';
         }
-        console.log('path', path.join(projectRoot, `public/${pathPrefix}`))
 
         return {
             filename: `[name]${hash}.js?_bid=152`,

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -145,7 +145,7 @@ class Builder {
         const cdn = options.cdn || '11.url.cn';
         const product = options.product || 'now';
         // Html 路径前缀, 打包时的目录
-        const htmlPrefix = moduleName ? `webserver/${bizName}` : 'webserver';
+        const htmlPrefix = moduleName ? `../../webserver/${bizName}` : '../../webserver';
         // Css, Js, Img等静态资源路径前缀, 打包时的目录
         const assetsPrefix = moduleName ? `cdn/${bizName}` : 'cdn';
         const cdnUrl = moduleName ? `//${cdn}/${product}/${moduleName}/${bizName}` : `//${cdn}/${product}/${bizName}`;
@@ -158,7 +158,7 @@ class Builder {
         // 设置HTML解析规则
         prodRules.push(this.setHtmlRule());
         // 设置图片解析规则, 图片需要hash
-        prodRules.push(this.setImgRule(true, assetsPrefix));
+        prodRules.push(this.setImgRule(true, ''));
         // 设置CSS解析规则
         prodRules.push(this.setCssRule());
         // 设置Less解析规则，生产环境默认压缩CSS
@@ -180,7 +180,7 @@ class Builder {
         }));
         prodPlugins.push(new StringReplaceWebpackPlugin());
         // 设置提取CSS为一个单独的文件的插件
-        prodPlugins.push(this.setMiniCssExtractPlugin(true, assetsPrefix));
+        prodPlugins.push(this.setMiniCssExtractPlugin(true, ''));
         if (options.minifyJS) {
             // 压缩JS
             prodPlugins.push(new UglifyJsPlugin({
@@ -244,20 +244,16 @@ class Builder {
      * @private
      */
     static setOutput(useHash, pathPrefix, publicPath) {
-        let filename = '';
         let hash = '';
-
-        if (pathPrefix) {
-            filename = pathPrefix + '/';
-        }
 
         if (useHash) {
             hash = '_[chunkhash:8]';
         }
+        console.log('path', path.join(projectRoot, `public/${pathPrefix}`))
 
         return {
-            filename: `${filename}[name]${hash}.js?_bid=152`,
-            path: path.join(projectRoot, 'public/'),
+            filename: `[name]${hash}.js?_bid=152`,
+            path: path.join(projectRoot, `public/${pathPrefix}`),
             publicPath: publicPath,
             crossOriginLoading: 'anonymous'
         };
@@ -558,7 +554,7 @@ class Builder {
                     template: path.join(projectRoot, `src/pages/${pageName}/index.html`),
                     filename: `${filename}${pageName}.html`,
                     chunks: [pageName],
-                    assetsPrefix: `${assetsPrefix}/`,
+                    // assetsPrefix: `${assetsPrefix}/`, 
                     inject: inject && isEntryFileExists,
                     minify: minifyHtml
                         ? {


### PR DESCRIPTION
 为了符合产生以下资源路径
```
public
├── cdn
│   └── category
│       ├── img
│       │   └── loading_f370f0e3.gif
│       ├── index_1a787ef6.js
│       └── index_461b3416.css
└── webserver
    └── category
        └── index.html
```
需要将path指向`cdn`，html插件生成的`webserver`指向其同级